### PR TITLE
Remove compat entries for differentiation libraries

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,24 +22,20 @@ ReferenceFrameRotationsZygoteExt = ["ForwardDiff", "Zygote"]
 [compat]
 Crayons = "4.0"
 DifferentiationInterface = "0.6"
-FiniteDiff = "2.26"
-ForwardDiff = "0.10"
 LinearAlgebra = "1.6"
-Mooncake = "0.4"
 Printf = "1.6"
 Random = "1.6"
 StableRNGs = "1"
 StaticArrays = "1"
 Test = "1.6"
-Zygote = "0.6"
-julia = "1.10"
+julia = "1.10, 1.11, 1.12"
 
 [extras]
 DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
-Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Test", "DifferentiationInterface", "FiniteDiff", "Mooncake", "StableRNGs", "Zygote"]
+test = ["Test", "DifferentiationInterface", "FiniteDiff", "StableRNGs", "Zygote"]

--- a/test/differentiability/dcm.jl
+++ b/test/differentiability/dcm.jl
@@ -34,10 +34,6 @@
     f_fd, df_fd = value_and_jacobian((x) -> orthonormalize(DCM(x)), AutoFiniteDiff(), data)
     f_ad, df_ad = value_and_jacobian((x) -> orthonormalize(DCM(x)), AutoZygote(), data)
 
-    f_adm, df_adm = value_and_jacobian(
-        (x) -> Array(orthonormalize(DCM(x))), AutoMooncake(; config = nothing), data
-    )
-
     @test f_ad == f_fd
     @test df_ad ≈ df_fd rtol = 1e-7
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ using StaticArrays
 
 import Base: isapprox
 
-using DifferentiationInterface, FiniteDiff, Mooncake, Zygote
+using DifferentiationInterface, FiniteDiff, Zygote
 
 ############################################################################################
 #                                   Auxiliary Functions                                    #


### PR DESCRIPTION
This PR removes the compat entries for differentiation libraries which prevented some of them from updating to newer versions. I have left the compat entry for `DifferentiationInterface`.

The tests are also modified to remove the requirements for `Mooncake` which was not used and currently has issues updating to Julia 1.12 which I am currently using. All tests now pass on this version.

It may be important to add some kind of extension compat for the Zygote extension since this uses the Zygote internal methods.