### PR TITLE
Fix  nightly ci & compat cleanup

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,11 +21,8 @@ ReferenceFrameRotationsZygoteExt = ["ForwardDiff", "Zygote"]
 
 [compat]
 Crayons = "4.0"
-DifferentiationInterface = "0.6"
-FiniteDiff = "2.26"
 ForwardDiff = "0.10, 1"
 LinearAlgebra = "1.6"
-Mooncake = "0.4"
 Printf = "1.6"
 Random = "1.6"
 StableRNGs = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -34,9 +34,8 @@ julia = "1.10"
 [extras]
 DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
-Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "DifferentiationInterface", "FiniteDiff", "Mooncake", "StableRNGs", "Zygote"]
+test = ["Test", "DifferentiationInterface", "FiniteDiff", "StableRNGs", "Zygote"]

--- a/test/differentiability/dcm.jl
+++ b/test/differentiability/dcm.jl
@@ -33,11 +33,4 @@
 
     f_fd, df_fd = value_and_jacobian((x) -> orthonormalize(DCM(x)), AutoFiniteDiff(), data)
     f_ad, df_ad = value_and_jacobian((x) -> orthonormalize(DCM(x)), AutoZygote(), data)
-
-    f_adm, df_adm = value_and_jacobian(
-        (x) -> Array(orthonormalize(DCM(x))), AutoMooncake(; config = nothing), data
-    )
-
-    @test f_ad == f_fd
-    @test df_ad ≈ df_fd rtol = 1e-7
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ using StaticArrays
 
 import Base: isapprox
 
-using DifferentiationInterface, FiniteDiff, Mooncake, Zygote
+using DifferentiationInterface, FiniteDiff, Zygote
 
 ############################################################################################
 #                                   Auxiliary Functions                                    #


### PR DESCRIPTION
I removed the Mooncake test and package as it wasn't really adding anything here. The precompilation error might be a problem in my other PR's but I don't think we need to deal with it here. I also removed the compat entries for packages only in extras